### PR TITLE
Сохранение user_id Telegram API в бд оркестратора

### DIFF
--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/mapper/UserMapper.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/mapper/UserMapper.java
@@ -13,6 +13,7 @@ public class UserMapper {
 
     public User mapTelegramAuthToUser(TelegramAuthRequest telegramAuthRequest) {
         User user = new User();
+        user.setId(telegramAuthRequest.getId());
         user.setUsername(telegramAuthRequest.getUsername());
         user.setFirstName(telegramAuthRequest.getFirst_name());
         user.setLastName(telegramAuthRequest.getLast_name());

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/model/TelegramAuthRequest.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/model/TelegramAuthRequest.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TelegramAuthRequest {
 
-    private String id;
+    private Long id;
 
     private String first_name;
 

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/service/JwtAuthenticationService.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/service/JwtAuthenticationService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import javax.management.InstanceNotFoundException;
 import javax.naming.AuthenticationException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/service/UserService.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/service/UserService.java
@@ -32,20 +32,20 @@ public class UserService {
     }
 
     public void saveUser(TelegramAuthRequest telegramAuthRequest) {
-        if (Objects.isNull(getUserByUsername(telegramAuthRequest.getUsername()))) {
+        if (Objects.isNull(getUserById(telegramAuthRequest.getId()))) {
             userRepository.save(userMapper.mapTelegramAuthToUser(telegramAuthRequest));
         }
     }
 
-    public User getUserById(Long id) throws InstanceNotFoundException {
-        return userRepository.findById(id).orElseThrow(() -> new InstanceNotFoundException("Error: no user with this ID"));
+    public User getUserById(Long id) {
+        return userRepository.findById(id).orElse(null);
     }
 
     public User getUserByUsername(String username) {
         return userRepository.findByUsername(username);
     }
 
-    public void updateUser(User user, Long id) throws InstanceNotFoundException {
+    public void updateUser(User user, Long id) {
         User foundUser = getUserById(id);
         foundUser.setFirstName(user.getFirstName());
         foundUser.setLastName(user.getLastName());


### PR DESCRIPTION
ID юзера в базе данных теперь идентично user_id из Telegram API

При авторизации проверяется наличие ID в бд (вместо юзернейма, который может быть изменен пользователем)

