### PR TITLE
Added spring profiles to remove local logs in elastic

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -75,6 +75,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD }}
           script: |
+            echo SPRING_APPLICATION_PROFILE = test >> overmoney-env.txt
             echo RECOGNIZER_DB_USER = ${{ secrets.RECOGNIZER_DB_USER }} > overmoney-env.txt
             echo RECOGNIZER_DB_PASSWORD = ${{ secrets.RECOGNIZER_DB_PASSWORD }} >> overmoney-env.txt
             echo RECOGNIZER_DB_PORT = 5432 >> overmoney-env.txt

--- a/eureka_service/src/main/resources/application.yml
+++ b/eureka_service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
   spring:
     application:
       name: eureka_service
+    profiles:
+      active: ${SPRING_APPLICATION_PROFILE:dev}
 
   server:
     port: 8761

--- a/eureka_service/src/main/resources/logback-spring.xml
+++ b/eureka_service/src/main/resources/logback-spring.xml
@@ -1,30 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <destination>178.250.152.37:5000</destination>
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <mdc />
-                <context />
-                <logLevel />
-                <loggerName />
-                <pattern>
+    <springProfile name="!dev">
+        <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+            <destination>178.250.152.37:5000</destination>
+            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                <providers>
+                    <mdc/>
+                    <context/>
+                    <logLevel/>
+                    <loggerName/>
                     <pattern>
-                        {
-                        "app": "eureka"
-                        }
+                        <pattern>
+                            {
+                            "app": "eureka"
+                            }
+                        </pattern>
                     </pattern>
-                </pattern>
-                <threadName />
-                <message />
-                <logstashMarkers />
-                <stackTrace />
-            </providers>
-        </encoder>
-    </appender>
-    <root level="info">
-        <appender-ref ref="logstash" />
-    </root>
+                    <threadName/>
+                    <message/>
+                    <logstashMarkers/>
+                    <stackTrace/>
+                </providers>
+            </encoder>
+        </appender>
+        <root level="info">
+            <appender-ref ref="logstash"/>
+        </root>
+    </springProfile>
 </configuration>
 

--- a/orchestrator_service/src/main/resources/application.yml
+++ b/orchestrator_service/src/main/resources/application.yml
@@ -48,6 +48,9 @@
       enabled: true
       change-log: /db/changelog/db.changelog-master.xml
 
+    profiles:
+      active: ${SPRING_APPLICATION_PROFILE:dev}
+
   eureka:
     client:
       serviceUrl:

--- a/orchestrator_service/src/main/resources/logback-spring.xml
+++ b/orchestrator_service/src/main/resources/logback-spring.xml
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <destination>178.250.152.37:5000</destination>
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <mdc />
-                <context />
-                <logLevel />
-                <loggerName />
-                <pattern>
+    <springProfile name="!dev">
+        <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+            <destination>178.250.152.37:5000</destination>
+            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                <providers>
+                    <mdc/>
+                    <context/>
+                    <logLevel/>
+                    <loggerName/>
                     <pattern>
-                        {
-                        "app": "orchestrator"
-                        }
+                        <pattern>
+                            {
+                            "app": "orchestrator"
+                            }
+                        </pattern>
                     </pattern>
-                </pattern>
-                <threadName />
-                <message />
-                <logstashMarkers />
-                <stackTrace />
-            </providers>
-        </encoder>
-    </appender>
-    <root level="info">
-        <appender-ref ref="logstash" />
-    </root>
+                    <threadName/>
+                    <message/>
+                    <logstashMarkers/>
+                    <stackTrace/>
+                </providers>
+            </encoder>
+        </appender>
+        <root level="info">
+            <appender-ref ref="logstash"/>
+        </root>
+    </springProfile>
 </configuration>

--- a/recognizer_service/src/main/resources/application.yml
+++ b/recognizer_service/src/main/resources/application.yml
@@ -26,6 +26,9 @@
       enabled: true
       change-log: /db/changelog/db.changelog-1.0.xml
 
+    profiles:
+      active: ${SPRING_APPLICATION_PROFILE:dev}
+
   eureka:
     client:
       serviceUrl:

--- a/recognizer_service/src/main/resources/logback-spring.xml
+++ b/recognizer_service/src/main/resources/logback-spring.xml
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <destination>178.250.152.37:5000</destination>
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <mdc />
-                <context />
-                <logLevel />
-                <loggerName />
-                <pattern>
+    <springProfile name="!dev">
+        <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+            <destination>178.250.152.37:5000</destination>
+            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                <providers>
+                    <mdc/>
+                    <context/>
+                    <logLevel/>
+                    <loggerName/>
                     <pattern>
-                        {
-                        "app": "recognizer"
-                        }
+                        <pattern>
+                            {
+                            "app": "recognizer"
+                            }
+                        </pattern>
                     </pattern>
-                </pattern>
-                <threadName />
-                <message />
-                <logstashMarkers />
-                <stackTrace />
-            </providers>
-        </encoder>
-    </appender>
-    <root level="info">
-        <appender-ref ref="logstash" />
-    </root>
+                    <threadName/>
+                    <message/>
+                    <logstashMarkers/>
+                    <stackTrace/>
+                </providers>
+            </encoder>
+        </appender>
+        <root level="info">
+            <appender-ref ref="logstash"/>
+        </root>
+    </springProfile>
 </configuration>

--- a/telegram_bot_service/src/main/resources/application.yml
+++ b/telegram_bot_service/src/main/resources/application.yml
@@ -34,6 +34,9 @@
       enabled: true
       change-log: /db/changelog/db.changelog-1.0.xml
 
+    profiles:
+      active: ${SPRING_APPLICATION_PROFILE:dev}
+
   eureka:
     client:
       serviceUrl:

--- a/telegram_bot_service/src/main/resources/logback-spring.xml
+++ b/telegram_bot_service/src/main/resources/logback-spring.xml
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <destination>178.250.152.37:5000</destination>
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <mdc />
-                <context />
-                <logLevel />
-                <loggerName />
-                <pattern>
+    <springProfile name="!dev">
+        <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+            <destination>178.250.152.37:5000</destination>
+            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                <providers>
+                    <mdc/>
+                    <context/>
+                    <logLevel/>
+                    <loggerName/>
                     <pattern>
-                        {
-                        "app": "telegram-bot"
-                        }
+                        <pattern>
+                            {
+                            "app": "telegram-bot"
+                            }
+                        </pattern>
                     </pattern>
-                </pattern>
-                <threadName />
-                <message />
-                <logstashMarkers />
-                <stackTrace />
-            </providers>
-        </encoder>
-    </appender>
-    <root level="info">
-        <appender-ref ref="logstash" />
-    </root>
+                    <threadName/>
+                    <message/>
+                    <logstashMarkers/>
+                    <stackTrace/>
+                </providers>
+            </encoder>
+        </appender>
+        <root level="info">
+            <appender-ref ref="logstash"/>
+        </root>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
Добавил спринг профиль для корректной записи только нужных логов в эластик. Логи локальных микросервисов не будут передаваться в эластик при условии, если выбран спринг профиль = dev(он выбран по умолчанию). Все остальные профили будут отправлять логи на эластик