### PR TITLE
Fixed bug with viewing keywords after page update

### DIFF
--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/controller/rest/CategoryController.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/controller/rest/CategoryController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.management.InstanceNotFoundException;
 import java.security.Principal;
 import java.util.List;
+import java.util.UUID;
 
 import static com.override.orchestrator_service.util.TelegramUtils.getTelegramId;
 
@@ -30,6 +31,11 @@ public class CategoryController {
     @GetMapping("/")
     public List<CategoryDTO> getCategoriesList(Principal principal) throws InstanceNotFoundException {
         return categoryService.findCategoriesListByUserId(getTelegramId(principal));
+    }
+
+    @GetMapping("/{id}")
+    public CategoryDTO getCategoryByCategoryId(@PathVariable("id") UUID id) {
+        return categoryService.findCategoryById(id);
     }
 
     @PostMapping("/add-default-categories")

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/service/CategoryService.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/service/CategoryService.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 
 @Service
 public class CategoryService {
-
     @Autowired
     private CategoryRepository categoryRepository;
     @Autowired
@@ -36,6 +35,11 @@ public class CategoryService {
 
     public Category getCategoryById(UUID categoryId) {
         return categoryRepository.findById(categoryId).orElseThrow(CategoryNotFoundException::new);
+    }
+
+    public CategoryDTO findCategoryById(UUID categoryId) {
+        return categoryMapper.mapCategoryToJsonResponse(
+                categoryRepository.findById(categoryId).orElseThrow(CategoryNotFoundException::new));
     }
 
     public void setDefaultCategoryForAccount(Long id) throws InstanceNotFoundException {

--- a/orchestrator_service/src/main/resources/static/scripts/overview_scripts.js
+++ b/orchestrator_service/src/main/resources/static/scripts/overview_scripts.js
@@ -72,6 +72,30 @@ function getCategoriesData() {
     })
 }
 
+function getCategoryById(id) {
+    let url = './categories/' + id;
+    let category;
+    $.ajax({
+        method: 'GET',
+        url: url,
+        contentType: "application/json; charset=utf8",
+        async: false,
+        success: function (data) {
+            console.log("Successfully get category")
+            console.log(data)
+            category = data
+            if (data.length === 0) {
+                console.log("data is null")
+            }
+        },
+        error: function () {
+            console.log("ERROR! Something wrong happened")
+        }
+    })
+    console.log(category)
+    return category;
+}
+
 function drawModalDefaultCategories() {
     let modal = document.getElementById("modal-default-category");
     modal.style.display = "block";
@@ -204,14 +228,15 @@ function drawCategory(category, length) {
     newCategory.dataset.id = category.id;
     newCategory.dataset.name = category.name;
     let type;
-    if(category.type == "INCOME"){
+    if (category.type == "INCOME") {
         type = "Доходы";
-    } else if (category.type == "EXPENSE"){
+    } else if (category.type == "EXPENSE") {
         type = "Расходы"
     }
     newCategory.dataset.type = type;
     newCategory.dataset.keywords = keywords;
     newCategory.onclick = function () {
+        keywords = writeKeywordsOfCategory(getCategoryById(newCategory.dataset.id));
         let body = `<h3>Информация о категории</h3>
                     <form class="modal-category">
                    <p class="modal-category-close" href="#">X</p>
@@ -225,7 +250,7 @@ function drawCategory(category, length) {
                         </div>
                         <div>
                             <label for="keywords">Ключевые слова категории:</label>
-                            <input type="text" readonly class="input-modal-category" id="keywords" value="${newCategory.dataset.keywords}">
+                            <input type="text" readonly class="input-modal-category" id="keywords" value="${keywords}">
                         </div>
                     </form>`
         $('.modal-category-content').html(body)
@@ -235,8 +260,6 @@ function drawCategory(category, length) {
         $('.modal-category-close').click(function () {
             $(this).parents('.modal-category-fade').fadeOut();
         });
-
-
     }
     categorySpace.insertAdjacentElement('beforeend', newCategory);
 
@@ -300,10 +323,8 @@ function drawModalToAddCategory() {
             console.log(JSON.stringify(data));
             createNewCategory(data);
             $(this).parents('.modal-category-fade').fadeOut();
+            location.reload();
         }
-
-        location.reload();
-
     });
 }
 


### PR DESCRIPTION
Исправлен баг, при котором после драгНдропа транзакции в категорию, ключевое слово транзакции появлялось в модальном окне о категории только после обновления страницы. Теперь при клике на категорию информация о ключевых словах берется напрямую из бэка, а не из data html страницы