### PR TITLE
Добавлена модель для хранения инфы о ТГ рассылках

### DIFF
--- a/dto/src/main/java/com/override/dto/constants/StatusMailing.java
+++ b/dto/src/main/java/com/override/dto/constants/StatusMailing.java
@@ -1,0 +1,13 @@
+package com.override.dto.constants;
+
+public enum StatusMailing {
+    SUCCESSFULLY("Успешно"),
+    ERROR("Ошибка"),
+    AWAIT_SENDING("Ожидание отправки");
+
+    private final String value;
+
+    StatusMailing(String value) {
+        this.value = value;
+    }
+}

--- a/telegram_bot_service/pom.xml
+++ b/telegram_bot_service/pom.xml
@@ -94,6 +94,11 @@
             <version>0.13.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/telegram_bot_service/src/main/java/com/overmoney/telegram_bot_service/config/MaxMessagesInSecondProperties.java
+++ b/telegram_bot_service/src/main/java/com/overmoney/telegram_bot_service/config/MaxMessagesInSecondProperties.java
@@ -1,0 +1,14 @@
+package com.overmoney.telegram_bot_service.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "max-mailing-messages")
+@Getter
+@Setter
+public class MaxMessagesInSecondProperties {
+    public long maxMessagesOfAnnouncePerSecond;
+}

--- a/telegram_bot_service/src/main/java/com/overmoney/telegram_bot_service/model/AnnounceMailing.java
+++ b/telegram_bot_service/src/main/java/com/overmoney/telegram_bot_service/model/AnnounceMailing.java
@@ -1,0 +1,30 @@
+package com.overmoney.telegram_bot_service.model;
+
+import com.override.dto.constants.StatusMailing;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "announse_mailing")
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class AnnounceMailing {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "telegram_id")
+    private Long telegramId;
+
+    @Column(name = "status_mailing")
+    private StatusMailing statusMailing;
+
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime date;
+}

--- a/telegram_bot_service/src/main/java/com/overmoney/telegram_bot_service/repository/AnnounceMailingRepository.java
+++ b/telegram_bot_service/src/main/java/com/overmoney/telegram_bot_service/repository/AnnounceMailingRepository.java
@@ -1,0 +1,9 @@
+package com.overmoney.telegram_bot_service.repository;
+
+import com.overmoney.telegram_bot_service.model.AnnounceMailing;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnnounceMailingRepository extends JpaRepository<AnnounceMailing, Long> {
+}

--- a/telegram_bot_service/src/main/resources/application.yml
+++ b/telegram_bot_service/src/main/resources/application.yml
@@ -32,7 +32,7 @@
 
     liquibase:
       enabled: true
-      change-log: /db/changelog/db.changelog-1.0.xml
+      change-log: /db/changelog/db.changelog-master.xml
 
     profiles:
       active: ${SPRING_APPLICATION_PROFILE:dev}
@@ -51,3 +51,6 @@
       web:
         exposure:
           include: "*"
+
+  max-mailing-messages:
+    maxMessagesOfAnnouncePerSecond: 25

--- a/telegram_bot_service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/telegram_bot_service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <include file="v1.0.0/db.changelog-1.0.xml" relativeToChangelogFile="true"/>
+    <include file="v1.0.0/001-db.changelog-createAnnounceMailingModel.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/telegram_bot_service/src/main/resources/db/changelog/v1.0.0/001-db.changelog-createAnnounceMailingModel.xml
+++ b/telegram_bot_service/src/main/resources/db/changelog/v1.0.0/001-db.changelog-createAnnounceMailingModel.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="17.06.23-createAnnounceMailing" author="NikitaAkimov">
+        <createTable tableName="announse_mailing">
+            <column name="id" type="BIGSERIAL">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="telegram_id" type="BIGINT"/>
+            <column name="status_mailing" type="INTEGER"/>
+            <column name="date" type="TIMESTAMP"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/telegram_bot_service/src/main/resources/db/changelog/v1.0.0/db.changelog-1.0.xml
+++ b/telegram_bot_service/src/main/resources/db/changelog/v1.0.0/db.changelog-1.0.xml
@@ -16,4 +16,5 @@
             <column name="auth_date" type="DATE"/>
         </createTable>
     </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
- Добавлен AnnounseMailing для хранения информации о статусе, времени рассылки, и кому была произведена рассылка
- Немного изменена структура xml файлов liquiBase в tg-bot-service
- Добавлена MaxMessagesInSecondProperties для получения максимального числа сообщений в секунду для рассылки бота, будет в дальнейшем использоваться, как ограничитель в sendAnnounce