### PR TITLE
Добавление валидации для проверки уникальности категории

### DIFF
--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/exception/CategoryNameIsNotUniqueException.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/exception/CategoryNameIsNotUniqueException.java
@@ -1,0 +1,23 @@
+package com.override.orchestrator_service.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CategoryNameIsNotUniqueException extends BaseException{
+    public CategoryNameIsNotUniqueException() {
+        super();
+    }
+
+    public CategoryNameIsNotUniqueException(String message) {
+        super(message);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+
+    @Override
+    public String getErrorCode() {
+        return "ORCHESTRA_CATEGORY_NAME_NOT_UNIQUE_EXCEPTION";
+    }
+}

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/mapper/CategoryMapper.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/mapper/CategoryMapper.java
@@ -7,6 +7,7 @@ import com.override.orchestrator_service.model.Category;
 import com.override.orchestrator_service.model.OverMoneyAccount;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.thymeleaf.util.StringUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -44,7 +45,7 @@ public class CategoryMapper {
 
     public Category mapCategoryDTOToCategory(CategoryDTO categoryDTO, OverMoneyAccount account) {
         return Category.builder()
-                .name(categoryDTO.getName())
+                .name(StringUtils.capitalize(categoryDTO.getName()))
                 .type(categoryDTO.getType())
                 .account(account)
                 .build();

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/model/Category.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/model/Category.java
@@ -7,7 +7,11 @@ import javax.persistence.*;
 import java.util.Set;
 
 @Entity
-@Table(name="categories")
+@Table(name = "categories",
+        uniqueConstraints =
+                {@UniqueConstraint
+                        (name = "UniqueAccIdAndCategoryName", columnNames = {"name", "account_id"})
+                })
 @RequiredArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -25,10 +29,10 @@ public class Category {
     @Column
     private Type type;
 
-    @OneToMany(mappedBy="category")
+    @OneToMany(mappedBy = "category")
     private Set<Transaction> transactions;
 
-    @OneToMany(mappedBy="category", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "category", cascade = CascadeType.PERSIST)
     private Set<Keyword> keywords;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/service/CategoryService.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.override.dto.CategoryDTO;
 import com.override.dto.MergeCategoryDTO;
 import com.override.dto.constants.Type;
 import com.override.orchestrator_service.config.DefaultCategoryProperties;
+import com.override.orchestrator_service.exception.CategoryNameIsNotUniqueException;
 import com.override.orchestrator_service.exception.CategoryNotFoundException;
 import com.override.orchestrator_service.mapper.AccountMapper;
 import com.override.orchestrator_service.mapper.CategoryMapper;
@@ -14,6 +15,7 @@ import com.override.orchestrator_service.repository.CategoryRepository;
 import com.override.orchestrator_service.repository.KeywordRepository;
 import com.override.orchestrator_service.repository.TransactionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,7 +70,12 @@ public class CategoryService {
 
     public void saveCategoryForAcc(Long id, CategoryDTO categoryDTO) throws InstanceNotFoundException {
         OverMoneyAccount account = accountService.getAccountByUserId(id);
-        categoryRepository.save(categoryMapper.mapCategoryDTOToCategory(categoryDTO, account));
+        try {
+            categoryRepository.save(categoryMapper.mapCategoryDTOToCategory(categoryDTO, account));
+        } catch (DataIntegrityViolationException e) {
+            throw new CategoryNameIsNotUniqueException("Наименование категории не уникально! " +
+                                                        "Пожалуйста, внесите другое наименование.");
+        }
     }
 
     public void updateCategoryForAcc(Long id, CategoryDTO categoryDTO) throws InstanceNotFoundException {
@@ -86,9 +93,9 @@ public class CategoryService {
         transactionRepository.updateCategoryId(categoryToMergeId, categoryToChangeId);
         categoryRepository.deleteById(categoryToMergeId);
     }
-  
+
     @Transactional
-    public void deleteKeyword(KeywordId keywordId){
+    public void deleteKeyword(KeywordId keywordId) {
         keywordRepository.deleteByKeywordId(keywordId);
     }
 }

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/service/CategoryService.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/service/CategoryService.java
@@ -73,8 +73,8 @@ public class CategoryService {
         try {
             categoryRepository.save(categoryMapper.mapCategoryDTOToCategory(categoryDTO, account));
         } catch (DataIntegrityViolationException e) {
-            throw new CategoryNameIsNotUniqueException("Наименование категории не уникально! " +
-                                                        "Пожалуйста, внесите другое наименование.");
+            throw new CategoryNameIsNotUniqueException("Наименование категории \""
+                    + categoryDTO.getName() + "\" не уникально!");
         }
     }
 

--- a/orchestrator_service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/orchestrator_service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,4 +8,6 @@
     <include file="v1.0.0/001-db.changelog-setSuggestedCategoryIdInTransaction.xml" relativeToChangelogFile="true"/>
     <include file="v1.0.0/002-db.changelog-setTelegramUserIdInTransaction.xml" relativeToChangelogFile="true"/>
     <include file="v1.0.0/003-db.changelog-deleteRolesInUsersTableAndDropRoleTable.xml" relativeToChangelogFile="true"/>
+    <include file="v1.0.0/004-db.changelog-addUniqueConstraintForCategories.xml" relativeToChangelogFile="true"/>
+
 </databaseChangeLog>

--- a/orchestrator_service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/orchestrator_service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,6 +8,6 @@
     <include file="v1.0.0/001-db.changelog-setSuggestedCategoryIdInTransaction.xml" relativeToChangelogFile="true"/>
     <include file="v1.0.0/002-db.changelog-setTelegramUserIdInTransaction.xml" relativeToChangelogFile="true"/>
     <include file="v1.0.0/003-db.changelog-deleteRolesInUsersTableAndDropRoleTable.xml" relativeToChangelogFile="true"/>
-    <include file="v1.0.0/004-db.changelog-addUniqueConstraintForCategories.xml" relativeToChangelogFile="true"/>
+    <include file="v1.0.0/005-db.changelog-addUniqueConstraintForCategories.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/orchestrator_service/src/main/resources/db/changelog/v1.0.0/004-db.changelog-addUniqueConstraintForCategories.xml
+++ b/orchestrator_service/src/main/resources/db/changelog/v1.0.0/004-db.changelog-addUniqueConstraintForCategories.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+
+    <changeSet author="DementiiD" id="22.06.23-dropTableRoles">
+     <addUniqueConstraint tableName="categories" columnNames="name, account_id" constraintName="UniqueAccIdAndCategoryName"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/orchestrator_service/src/main/resources/db/changelog/v1.0.0/005-db.changelog-addUniqueConstraintForCategories.xml
+++ b/orchestrator_service/src/main/resources/db/changelog/v1.0.0/005-db.changelog-addUniqueConstraintForCategories.xml
@@ -4,7 +4,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
 
-    <changeSet author="DementiiD" id="22.06.23-dropTableRoles">
+    <changeSet author="NikitaAkimov" id="29.06.23-addUniqueConstraintForCategories">
      <addUniqueConstraint tableName="categories" columnNames="name, account_id" constraintName="UniqueAccIdAndCategoryName"/>
     </changeSet>
 

--- a/orchestrator_service/src/main/resources/static/scripts/overview_scripts.js
+++ b/orchestrator_service/src/main/resources/static/scripts/overview_scripts.js
@@ -462,6 +462,7 @@ function drawModalToAddCategory() {
                    <p class="modal-category-close" href="#">X</p>
                         <div>
                             <label for="newCategoryName">Наименование категории:</label>
+                            <p class="error-name" id="errorName" style="display:none; color:red; margin: 0 auto 10px; width: 322px;"></p>
                             <input type="text" required class="input-modal-category" id="newCategoryName">
                         </div>
                         <div>
@@ -494,14 +495,18 @@ function drawModalToAddCategory() {
                 name: nameValue,
                 type: typeValue,
             }
-            createNewCategory(data);
-            $(this).parents('.modal-category-fade').fadeOut();
-            location.reload();
+            let checkError = createNewCategory(data)
+            console.log(checkError)
+            if (!checkError) {
+                $(this).parents('.modal-category-fade').fadeOut();
+                location.reload();
+            }
         }
     });
 }
 
 function createNewCategory(category) {
+    let checkError = false;
     $.ajax({
         type: 'POST',
         url: './categories/',
@@ -511,13 +516,17 @@ function createNewCategory(category) {
         data: JSON.stringify(category),
         async: false,
         dataType: 'json',
-        success: function () {
-            console.log("Successfully created categories")
+        success: function (data) {
+            checkError = false;
+            console.log("Все заебись")
         },
         error: function (error) {
-            console.log(error)
+            console.log("Произошла ошибка")
+            checkError = true
+            drawCategoryNotUniqueException(error)
         }
     })
+    return checkError;
 }
 
 function updateCategory(category) {
@@ -660,5 +669,13 @@ function deleteKeyword(keywordId) {
             console.log(error)
         }
     })
+}
+
+function drawCategoryNotUniqueException(error) {
+    console.log(error.responseJSON.code)
+    if (error.responseJSON.code == "ORCHESTRA_CATEGORY_NAME_NOT_UNIQUE_EXCEPTION") {
+        $("#errorName").text(error.responseJSON.message);
+        document.getElementById("errorName").style.display = "block";
+    }
 
 }

--- a/orchestrator_service/src/main/resources/static/scripts/overview_scripts.js
+++ b/orchestrator_service/src/main/resources/static/scripts/overview_scripts.js
@@ -518,10 +518,8 @@ function createNewCategory(category) {
         dataType: 'json',
         success: function (data) {
             checkError = false;
-            console.log("Все заебись")
         },
         error: function (error) {
-            console.log("Произошла ошибка")
             checkError = true
             drawCategoryNotUniqueException(error)
         }

--- a/orchestrator_service/src/test/java/com/override/orchestrator_service/service/CategoryMapperTest.java
+++ b/orchestrator_service/src/test/java/com/override/orchestrator_service/service/CategoryMapperTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.thymeleaf.util.StringUtils;
 
 import java.util.*;
 
@@ -33,7 +34,7 @@ public class CategoryMapperTest {
         CategoryDTO categoryDTO = categoryMapper.mapCategoryToJsonResponse(category);
 
         Assertions.assertEquals(categoryDTO.getId(), category.getId());
-        Assertions.assertEquals(categoryDTO.getName(), category.getName());
+        Assertions.assertEquals(StringUtils.capitalize(categoryDTO.getName()),StringUtils.capitalize(category.getName()));
         Assertions.assertEquals(categoryDTO.getType(), category.getType());
         Assertions.assertEquals(categoryDTO.getKeywords().size(), category.getKeywords().size());
     }
@@ -46,7 +47,7 @@ public class CategoryMapperTest {
         final Category categoryTest = categoryMapper.mapCategoryDTOToCategory
                 (category, TestFieldsUtil.generateTestAccount());
 
-        Assertions.assertEquals(categoryTest.getName(), category.getName());
+        Assertions.assertEquals(categoryTest.getName(), StringUtils.capitalize(category.getName()));
         Assertions.assertEquals(categoryTest.getType(), category.getType());
     }
 }


### PR DESCRIPTION
- Добавлена проверка уникальности наименования категории(проверяется чтобы не было уникального сочетания account_id + name в таблице categories)
- Для корректной работы валидации при сохранении категории первая буква ее наименования записывается в верхнем регистре в БД
- Добавлена новый кастомный exception, вызывающийся в случае попытки записи неуникальной категории 
- На фронте теперь всплывает подсказка пользователю в случае указания им неуникального наименования категории
- Актуализированы юнит тесты