### PR TITLE
Развернуть Prometheus+Grafana

### DIFF
--- a/nginx/sites-enabled/overrideTech.ru
+++ b/nginx/sites-enabled/overrideTech.ru
@@ -81,4 +81,16 @@ server {
             proxy_pass http://localhost:9100/;
         }
 
+
+        location /orchestrator/actuator/prometheus/ {
+            proxy_pass http://localhost:8081/actuator/prometheus/;
+        }
+
+        location /telegram/actuator/prometheus/ {
+            proxy_pass http://localhost:8082/actuator/prometheus/;
+        }
+
+        location /recognizer/actuator/prometheus/ {
+            proxy_pass http://localhost:8080/actuator/prometheus/;
+        }
 }

--- a/orchestrator_service/pom.xml
+++ b/orchestrator_service/pom.xml
@@ -130,6 +130,11 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/config/SecurityConfig.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/templates/**", "/scripts/**", "/css/**").permitAll()
                 .antMatchers("/auth/**").permitAll()
                 .antMatchers("/login/**").permitAll()
-                .antMatchers("/actuator/health").permitAll()
+                .antMatchers("/actuator/health", "/actuator/prometheus").permitAll()
                 .antMatchers("/transaction", "/voice_message", "/account/**").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/orchestrator_service/src/main/resources/application.yml
+++ b/orchestrator_service/src/main/resources/application.yml
@@ -85,4 +85,11 @@
     endpoints:
       web:
         exposure:
-          include: "*"
+          include: health,prometheus
+    metrics:
+      export:
+        prometheus:
+          enabled: true
+      distribution:
+        percentiles-histogram:
+          "[http.server.requests]": true

--- a/recognizer_service/pom.xml
+++ b/recognizer_service/pom.xml
@@ -76,6 +76,11 @@
 			<version>0.0.1</version>
 			<scope>compile</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/recognizer_service/src/main/resources/application.yml
+++ b/recognizer_service/src/main/resources/application.yml
@@ -33,4 +33,11 @@
     endpoints:
       web:
         exposure:
-          include: "*"
+          include: health,prometheus
+    metrics:
+      export:
+        prometheus:
+          enabled: true
+      distribution:
+        percentiles-histogram:
+          "[http.server.requests]": true

--- a/recognizer_service/src/main/resources/application.yml
+++ b/recognizer_service/src/main/resources/application.yml
@@ -41,7 +41,6 @@
       distribution:
         percentiles-histogram:
           "[http.server.requests]": true
-          include: "*"
 
   audio-recognizer-go-service:
     url: ${AUDIO_RECOGNIZER_URL}

--- a/telegram_bot_service/pom.xml
+++ b/telegram_bot_service/pom.xml
@@ -99,6 +99,11 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/telegram_bot_service/src/main/resources/application.yml
+++ b/telegram_bot_service/src/main/resources/application.yml
@@ -54,7 +54,14 @@
     endpoints:
       web:
         exposure:
-          include: "*"
+          include: health,prometheus
+    metrics:
+      export:
+        prometheus:
+          enabled: true
+      distribution:
+        percentiles-histogram:
+          "[http.server.requests]": true
 
   max-mailing-messages:
     maxMessagesOfAnnouncePerSecond: 25


### PR DESCRIPTION
Часть задачи по разворачиванию prometheus+grafana, связанная с сервисами овермани telegram-bot, orchestrator, recognizer: 
- для сервисов открыта конечная точка /actuator/prometheus
- в настройках nginx добавлны конечные точки для доступа к статистике с внешней машины

- ! в настоящее время никакой аутентификации/авторизации не требуется, чтобы получить статистику сервисов