### PR TITLE
Отключено логирование ендпоинтов /actuator/**

### DIFF
--- a/eureka_service/src/main/java/com/override/eureka_service/config/LogbookConfig.java
+++ b/eureka_service/src/main/java/com/override/eureka_service/config/LogbookConfig.java
@@ -7,11 +7,17 @@ import org.zalando.logbook.DefaultSink;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.json.JsonHttpLogFormatter;
 
+import static org.zalando.logbook.Conditions.exclude;
+import static org.zalando.logbook.Conditions.requestTo;
+
 @Configuration
 public class LogbookConfig {
 
     @Bean
     public Logbook logbook() {
-        return Logbook.builder().sink(new DefaultSink(new JsonHttpLogFormatter(), new DefaultHttpLogWriter())).build();
+        return Logbook.builder()
+                .condition(exclude(requestTo("/actuator/**")))
+                .sink(new DefaultSink(new JsonHttpLogFormatter(), new DefaultHttpLogWriter()))
+                .build();
     }
 }

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/config/LogbookConfig.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/config/LogbookConfig.java
@@ -7,11 +7,17 @@ import org.zalando.logbook.DefaultSink;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.json.JsonHttpLogFormatter;
 
+import static org.zalando.logbook.Conditions.exclude;
+import static org.zalando.logbook.Conditions.requestTo;
+
 @Configuration
 public class LogbookConfig {
 
     @Bean
     public Logbook logbook() {
-        return Logbook.builder().sink(new DefaultSink(new JsonHttpLogFormatter(), new DefaultHttpLogWriter())).build();
+        return Logbook.builder()
+                .condition(exclude(requestTo("/actuator/**")))
+                .sink(new DefaultSink(new JsonHttpLogFormatter(), new DefaultHttpLogWriter()))
+                .build();
     }
 }

--- a/recognizer_service/src/main/java/com/override/recognizer_service/config/LogbookConfig.java
+++ b/recognizer_service/src/main/java/com/override/recognizer_service/config/LogbookConfig.java
@@ -7,11 +7,17 @@ import org.zalando.logbook.DefaultSink;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.json.JsonHttpLogFormatter;
 
+import static org.zalando.logbook.Conditions.exclude;
+import static org.zalando.logbook.Conditions.requestTo;
+
 @Configuration
 public class LogbookConfig {
 
     @Bean
     public Logbook logbook() {
-        return Logbook.builder().sink(new DefaultSink(new JsonHttpLogFormatter(), new DefaultHttpLogWriter())).build();
+        return Logbook.builder()
+                .condition(exclude(requestTo("/actuator/**")))
+                .sink(new DefaultSink(new JsonHttpLogFormatter(), new DefaultHttpLogWriter()))
+                .build();
     }
 }

--- a/telegram_bot_service/src/main/java/com/overmoney/telegram_bot_service/config/LogbookConfig.java
+++ b/telegram_bot_service/src/main/java/com/overmoney/telegram_bot_service/config/LogbookConfig.java
@@ -7,11 +7,17 @@ import org.zalando.logbook.DefaultSink;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.json.JsonHttpLogFormatter;
 
+import static org.zalando.logbook.Conditions.exclude;
+import static org.zalando.logbook.Conditions.requestTo;
+
 @Configuration
 public class LogbookConfig {
 
     @Bean
     public Logbook logbook() {
-        return Logbook.builder().sink(new DefaultSink(new JsonHttpLogFormatter(), new DefaultHttpLogWriter())).build();
+        return Logbook.builder()
+                .condition(exclude(requestTo("/actuator/**")))
+                .sink(new DefaultSink(new JsonHttpLogFormatter(), new DefaultHttpLogWriter()))
+                .build();
     }
 }


### PR DESCRIPTION
- Отключено логирование ендпоинтов "/actuator/**"
- Актуатор больше не пришлет логов в еластик и куда либо еще
- Изменены конфиги во всех 4х сервисах в LogbookConfig в @Bean Logbook добавлена настройка, кт исключает ендпоинты от "/actuator/**"