### PR TITLE
обрезаны и округлены суммы транзакции до 2 символов после запятой

### DIFF
--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/mapper/TransactionMapper.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/mapper/TransactionMapper.java
@@ -7,6 +7,8 @@ import com.override.orchestrator_service.model.Transaction;
 import org.springframework.stereotype.Component;
 
 import javax.management.InstanceNotFoundException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Objects;
 
 @Component
@@ -20,7 +22,7 @@ public class TransactionMapper {
                 .id(transaction.getId())
                 .type(getTransactionType(transaction))
                 .category(getTransactionCategory(transaction))
-                .amount(transaction.getAmount().toString())
+                .amount(roundAmount(transaction.getAmount()).toString())
                 .chatId(transaction.getAccount().getChatId())
                 .comment(transaction.getMessage())
                 .build();
@@ -29,7 +31,7 @@ public class TransactionMapper {
     public TransactionDTO mapTransactionToDTO(Transaction transaction) {
         TransactionDTO.TransactionDTOBuilder builder = TransactionDTO.builder()
                 .id(transaction.getId())
-                .amount(transaction.getAmount())
+                .amount(roundAmount(transaction.getAmount()))
                 .message(transaction.getMessage())
                 .date(transaction.getDate())
                 .suggestedCategoryId(transaction.getSuggestedCategoryId())
@@ -56,5 +58,9 @@ public class TransactionMapper {
             return CATEGORY_UNDEFINED;
         }
         return transaction.getCategory().getName();
+    }
+
+    private Float roundAmount(Float amount) {
+        return new BigDecimal(amount).setScale(2, RoundingMode.HALF_UP).floatValue();
     }
 }

--- a/orchestrator_service/src/test/java/com/override/orchestrator_service/service/TransactionMapperTest.java
+++ b/orchestrator_service/src/test/java/com/override/orchestrator_service/service/TransactionMapperTest.java
@@ -56,4 +56,26 @@ public class TransactionMapperTest {
         Assertions.assertEquals(transactionResponseDTO.getCategory(), transaction.getCategory().getName());
         Assertions.assertEquals(transactionResponseDTO.getAmount(), transaction.getAmount().toString());
     }
+
+    @Test
+    public void mapTransactionToTelegramResponseRoundAmountTest() throws InstanceNotFoundException {
+        Transaction transaction = TestFieldsUtil.generateTestTransaction();
+        transaction.setAmount(200.45678F);
+        String resultRoundAmount = "200.46";
+
+        TransactionResponseDTO transactionResponseDTO = transactionMapper.mapTransactionToTelegramResponse(transaction);
+
+        Assertions.assertEquals(transactionResponseDTO.getAmount(), resultRoundAmount);
+    }
+
+    @Test
+    public void mapTransactionToDTORoundAmountTest() {
+        Transaction transaction = TestFieldsUtil.generateTestTransaction();
+        transaction.setAmount(200.45678F);
+        Float resultRoundAmount = 200.46F;
+
+        TransactionDTO transactionDTO = transactionMapper.mapTransactionToDTO(transaction);
+
+        Assertions.assertEquals(transactionDTO.getAmount(), resultRoundAmount);
+    }
 }


### PR DESCRIPTION
- В TransactionMapper добавлен метод для округления и обрезки суммы транзакции до 2 символов после запятой
- Добавил тесты
- Транзакции округляются в мапперах для внешнего апи (в вебе на странице /history в ответе телеграм бота на добавление транзакции, в файлах бэкапа )