### PR TITLE
FIX - прописал dev-хост для ТГ-бота

### DIFF
--- a/orchestrator_service/src/main/resources/application-dev.yml
+++ b/orchestrator_service/src/main/resources/application-dev.yml
@@ -5,6 +5,7 @@
     internal:
       host:
         orchestrator: http://localhost:8081
+        telegram-bot: http://localhost:8082
         recognizer: http://localhost:8080
         invest: http://localhost:8087
 


### PR DESCRIPTION
В dev-профиле взаимодействие между оркестратором и другими сервисами осложнялось тем, что не хост ТГ-бота не был переопределен под локалхост:8082.

Переопределил.