### PR TITLE
FIX - не срабатывало удаление транзакции

### DIFF
--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/model/Transaction.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/model/Transaction.java
@@ -43,6 +43,6 @@ public class Transaction {
     @Nullable
     private Long telegramUserId;
 
-    @OneToOne(mappedBy = "transaction", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "transaction", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private Suggestion suggestion;
 }


### PR DESCRIPTION
После создания новой таблицы подсказок и построения двусторонней связи one-to-one между транзакцией и подсказкой при удалении транзакции происходил отказ (ограничение внешнего ключа).

Пофиксил через CascadeType.REMOVE, позволяющий удалять зависимые сущности при удалении транзакции.