### PR TITLE
Фейл транзакций при подборе категорий.

### DIFF
--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/kafka/consumerproducer/TransactionListener.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/kafka/consumerproducer/TransactionListener.java
@@ -15,6 +15,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+import javax.management.InstanceNotFoundException;
 import javax.transaction.Transactional;
 
 @Component
@@ -38,13 +39,10 @@ public class TransactionListener {
     private String responseTopic;
 
     @KafkaHandler
-    @Transactional
     public void processTransaction(TransactionMessageDTO transaction) {
 
         try {
-            Transaction currentTransactional = transactionProcessingService.processTransaction(transaction);
-            transactionService.saveTransaction(currentTransactional);
-            transactionProcessingService.suggestCategoryToProcessedTransaction(currentTransactional);
+            Transaction currentTransactional = this.preProcessTransaction(transaction);
 
             kafkaTemplate.send(responseTopic, transactionMapper
                     .mapTransactionToTelegramResponse(currentTransactional));
@@ -55,5 +53,13 @@ public class TransactionListener {
             log.error(e.getMessage());
             kafkaTemplate.send(responseTopic, errorResponse);
         }
+    }
+
+    @Transactional
+    public Transaction preProcessTransaction(TransactionMessageDTO transaction) throws InstanceNotFoundException {
+        Transaction currentTransactional = transactionProcessingService.processTransaction(transaction);
+        transactionService.saveTransaction(currentTransactional);
+        transactionProcessingService.suggestCategoryToProcessedTransaction(currentTransactional);
+        return currentTransactional;
     }
 }

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/repository/CategoryRepository.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/repository/CategoryRepository.java
@@ -3,6 +3,7 @@ package com.override.orchestrator_service.repository;
 import com.override.dto.AnalyticsDataDTO;
 import com.override.dto.constants.Type;
 import com.override.orchestrator_service.model.Category;
+import com.override.orchestrator_service.model.OverMoneyAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +16,13 @@ import java.util.Set;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query("SELECT c FROM Category c JOIN FETCH c.account a WHERE a = :account")
+    Set<Category> findCategoriesByOverMoneyAccount(@Param("account") OverMoneyAccount overMoneyAccount);
+
+    @Query("SELECT a FROM OverMoneyAccount a JOIN FETCH a.categories JOIN FETCH  a.users u " +
+            "WHERE u.id = :telegramAccountId")
+    OverMoneyAccount findOverMoneyAccountByTelegramId(@Param("telegramAccountId") Long telegramAccountId);
 
     Set<Category> findAllByAccount_Id(Long id);
 

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/service/CategoryService.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/service/CategoryService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.management.InstanceNotFoundException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -44,8 +45,9 @@ public class CategoryService {
     private UserService userService;
 
     public List<CategoryDTO> findCategoriesListByUserId(Long id) throws InstanceNotFoundException {
-        OverMoneyAccount account = accountService.getAccountByUserId(id);
-        return categoryMapper.mapCategoriesListToJsonResponse(accountMapper.mapAccountToCategoryList(account));
+        OverMoneyAccount account = categoryRepository.findOverMoneyAccountByTelegramId(id);
+        return categoryMapper.mapCategoriesListToJsonResponse(new ArrayList<>(categoryRepository
+                .findCategoriesByOverMoneyAccount(account)));
     }
 
     public List<CategoryDTO> findCategoriesListByChatId(Long id) {

--- a/orchestrator_service/src/main/java/com/override/orchestrator_service/service/TransactionProcessingService.java
+++ b/orchestrator_service/src/main/java/com/override/orchestrator_service/service/TransactionProcessingService.java
@@ -9,6 +9,7 @@ import com.override.orchestrator_service.util.TelegramUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import com.override.dto.TransactionMessageDTO;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.PostConstruct;
 import javax.management.InstanceNotFoundException;
@@ -74,6 +75,7 @@ public class TransactionProcessingService {
      * @see com.override.orchestrator_service.service.calc.TransactionHandler
      * @see com.override.orchestrator_service.service.calc.TransactionHandlerImplInvalidTransaction
      */
+    @Transactional
     public Transaction processTransaction(TransactionMessageDTO transactionMessageDTO) {
         OverMoneyAccount overMoneyAccount = overMoneyAccountService
                 .getOverMoneyAccountByChatId(transactionMessageDTO.getChatId());
@@ -127,6 +129,7 @@ public class TransactionProcessingService {
         return processTransaction(transactionMessageDTO);
     }
 
+    @Transactional
     public void suggestCategoryToProcessedTransaction(Transaction transaction)
             throws InstanceNotFoundException {
         List<CategoryDTO> categories = categoryService.findCategoriesListByUserId(transaction.getTelegramUserId());

--- a/orchestrator_service/src/main/resources/application.yml
+++ b/orchestrator_service/src/main/resources/application.yml
@@ -10,7 +10,7 @@
   # Для выбора kafka необходимо установить значение processing: kafka
   service:
     transaction:
-      processing: orchestrator
+      processing: kafka
 
   integration:
     internal:

--- a/telegram_bot_service/src/main/resources/application.yml
+++ b/telegram_bot_service/src/main/resources/application.yml
@@ -29,7 +29,7 @@
 # Для выбора kafka необходимо установить значение processing: kafka
   service:
     transaction:
-      processing: orchestrator
+      processing: kafka
 
   spring:
     application:


### PR DESCRIPTION
При использовании kafka при обработке транзакций происходили TransactionNotFoundException и отказ механизма подбора категории тразнакции при том, что сама транзакция сохранялась.

Решали через реорганизацию работы TransactionListener, AlexeyVolkovProg победил проблему ленивой инициализации, избежав использования Eager fetch.