### PR TITLE
убрала html из логов orchestrator

### DIFF
--- a/mask_log_starter/src/main/java/com/override/mask_log/config/MaskLogConfiguration.java
+++ b/mask_log_starter/src/main/java/com/override/mask_log/config/MaskLogConfiguration.java
@@ -1,6 +1,7 @@
 package com.override.mask_log.config;
 
 import com.override.mask_log.impl.formatter.MaskLogFormatter;
+import com.override.mask_log.impl.http.CustomSink;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -23,12 +24,8 @@ public class MaskLogConfiguration {
                 .condition(exclude(
                         requestTo("/actuator/**"),
                         requestTo("/scripts/**"),
-                        requestTo("/css/**"),
-                        contentType("text/html;charset=UTF-8")))
-//                ниже вариация вместо полного отсечения логов по html
-//                .responseFilter(ResponseFilters.replaceBody(message -> contentType("text/html;charset=UTF-8")
-//                .test(message) ? "some HTML code" : null))
-                .sink(new DefaultSink(maskLogFormatter, new DefaultHttpLogWriter()))
+                        requestTo("/css/**")))
+                .sink(new CustomSink(maskLogFormatter, new DefaultHttpLogWriter()))
                 .build();
     }
 }

--- a/mask_log_starter/src/main/java/com/override/mask_log/config/MaskLogConfiguration.java
+++ b/mask_log_starter/src/main/java/com/override/mask_log/config/MaskLogConfiguration.java
@@ -1,7 +1,7 @@
 package com.override.mask_log.config;
 
 import com.override.mask_log.impl.formatter.MaskLogFormatter;
-import com.override.mask_log.impl.http.CustomSink;
+import com.override.mask_log.impl.http.LoggableExcludingHtml;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +25,7 @@ public class MaskLogConfiguration {
                         requestTo("/actuator/**"),
                         requestTo("/scripts/**"),
                         requestTo("/css/**")))
-                .sink(new CustomSink(maskLogFormatter, new DefaultHttpLogWriter()))
+                .sink(new LoggableExcludingHtml(maskLogFormatter, new DefaultHttpLogWriter()))
                 .build();
     }
 }

--- a/mask_log_starter/src/main/java/com/override/mask_log/impl/http/CustomSink.java
+++ b/mask_log_starter/src/main/java/com/override/mask_log/impl/http/CustomSink.java
@@ -1,0 +1,44 @@
+package com.override.mask_log.impl.http;
+
+import java.io.IOException;
+import org.jetbrains.annotations.NotNull;
+import org.zalando.logbook.*;
+import org.zalando.logbook.Sink;
+
+public class CustomSink implements Sink {
+
+    private final HttpLogFormatter formatter;
+    private final HttpLogWriter writer;
+
+    public CustomSink(HttpLogFormatter formatter, HttpLogWriter writer) {
+        this.formatter = formatter;
+        this.writer = writer;
+    }
+
+    @Override
+    public void write(final @NotNull Precorrelation precorrelation, final HttpRequest request)
+        throws IOException {
+        String requestBody = new String(request.getBody());
+
+        if (shouldLog(requestBody)) {
+            final String requestLog = formatter.format(precorrelation, request);
+            writer.write(precorrelation, requestLog);
+        }
+    }
+
+    @Override
+    public void write(final @NotNull Correlation correlation, final HttpRequest request,
+            final HttpResponse response) throws IOException {
+
+        String responseBody = new String(response.getBody());
+
+        if (shouldLog(responseBody)) {
+            final String responseLog = formatter.format(correlation, response);
+            writer.write(correlation, responseLog);
+        }
+    }
+
+    private boolean shouldLog(String body) {
+        return (body.contains("\"type\":\"request\"") || body.contains("\"type\":\"response\""));
+    }
+}

--- a/mask_log_starter/src/main/java/com/override/mask_log/impl/http/LoggableExcludingHtml.java
+++ b/mask_log_starter/src/main/java/com/override/mask_log/impl/http/LoggableExcludingHtml.java
@@ -5,12 +5,12 @@ import org.jetbrains.annotations.NotNull;
 import org.zalando.logbook.*;
 import org.zalando.logbook.Sink;
 
-public class CustomSink implements Sink {
+public class LoggableExcludingHtml implements Sink {
 
     private final HttpLogFormatter formatter;
     private final HttpLogWriter writer;
 
-    public CustomSink(HttpLogFormatter formatter, HttpLogWriter writer) {
+    public LoggableExcludingHtml(HttpLogFormatter formatter, HttpLogWriter writer) {
         this.formatter = formatter;
         this.writer = writer;
     }
@@ -39,6 +39,6 @@ public class CustomSink implements Sink {
     }
 
     private boolean shouldLog(String body) {
-        return (body.contains("\"type\":\"request\"") || body.contains("\"type\":\"response\""));
+        return !body.contains("<!DOCTYPE html>");
     }
 }


### PR DESCRIPTION
имплементировала интерфейс Sink, что позволило убрать из логов сообщения, которые содержат request или response