### PR TITLE
Fix/ov 321  | AdminPageFilter fix

### DIFF
--- a/charts/ingress/values-qa.yaml
+++ b/charts/ingress/values-qa.yaml
@@ -29,3 +29,7 @@ rules:
               number: 80
 annotations:
   cert-manager.io/cluster-issuer: letsencrypt-staging
+  nginx.ingress.kubernetes.io/enable-cors: "true"
+  nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+  nginx.ingress.kubernetes.io/cors-allow-methods: "*"
+  nginx.ingress.kubernetes.io/cors-allow-headers: "*"


### PR DESCRIPTION
1)fix NPE
2)fix IllegalStateException

убрал логику в который без проверки на токена на нал, явно вызывался предидущий фильтр цепочки SecurityFilterChain, заменил на использование SecurityContextHolder'а